### PR TITLE
TECH-4118 - Enable remote, manual trigger via webhook

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -13,7 +13,10 @@ on:
           - 'staging'
           - 'development'
   schedule:
-    - cron: '13 */1 * * *'
+    - cron: '13 * * * *'
+  repository_dispatch:
+    types:
+      - manual-trigger-by-devs
 
 env:
   UPSTREAM_REPO: 'jetstreamgg/marketing-page'


### PR DESCRIPTION
In order to be able to run the webhook, you also need to present a valid token but that's not something that has to be configured here. This `repository_dispatch` is only needed in the default branch.