### PR TITLE
feat: topology spread constraints for better scaling in prod

### DIFF
--- a/deploy/values.yml
+++ b/deploy/values.yml
@@ -54,6 +54,35 @@ readinessProbe:
   initialDelaySeconds: 6
   periodSeconds: 20
 
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:
+          - on-demand
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+            - key: app.kubernetes.io/name
+              operator: In
+              values:
+                - '${APP_NAME}'
+        topologyKey: "kubernetes.io/hostname"
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: '${APP_NAME}'
+
 autoscaling:
   enabled: true
   minReplicas: 1


### PR DESCRIPTION
This strategy can make sure pods are preferably placed on on-demand nodes by using node affinity with the label karpenter.sh/capacity-type=on-demand. 
It also tries to spread pods of the same application across different nodes using a soft pod anti-affinity rule based on the label app.kubernetes.io/name. 
The topology spread constraints aim to distribute pods evenly across nodes (by kubernetes.io/hostname) with maxSkew=1, but allow scheduling to proceed even if perfect spreading isn’t possible.

If the app scales up to 20 pods and the cluster only has 5 on-demand nodes, the scheduler will attempt to place 4 pods per node while maximizing distribution. If resource limits are hit or spreading fails, it will still schedule the pods to avoid blocking the deployment.