### PR TITLE
feat: spread pod on to on-demand and spot instance

### DIFF
--- a/deploy/values.yml
+++ b/deploy/values.yml
@@ -77,7 +77,7 @@ topologySpreadConstraints:
 
 autoscaling:
   enabled: true
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: ${MAX_REPLICAS}
   targetCPUUtilizationPercentage: 85
   targetMemoryUtilizationPercentage: 85

--- a/deploy/values.yml
+++ b/deploy/values.yml
@@ -55,14 +55,6 @@ readinessProbe:
   periodSeconds: 20
 
 affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: karpenter.sh/capacity-type
-          operator: In
-          values:
-          - on-demand
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
     - weight: 100


### PR DESCRIPTION
Get rid of the nodeAffinity for on-demand only. 